### PR TITLE
Lexically scoped policy files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ MYMETA.yml
 Makefile.old
 blib/
 pm_to_blib
+MYMETA.json
+*~
+GENERATED.pl

--- a/MANIFEST
+++ b/MANIFEST
@@ -51,6 +51,7 @@ t/slaughter-api-misc-tests.t
 t/slaughter-api-shell-tests.t
 t/slaughter-api-text-tests.t
 t/slaughter-api-user-tests.t
+t/test-bin-slaughter.t
 t/style-no-tabs.t
 t/test-dependencies.t
 t/test-digest-sha-module.t
@@ -59,4 +60,9 @@ t/test-lib-slaughter-packages.t
 t/test-lib-slaughter-transport.t
 t/test-pod-syntax.t
 t/test-text-template-module.t
+t/example1/policies/foo.policy
+t/example1/policies/bar.policy
+t/example1/modules/Foo.pm
+t/example1/modules/Bar.pm
+
 TRANSPORTS

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,19 +18,23 @@ my %WriteMakefileArgs = (
         'File::Spec'      => 0,
         'File::Temp'      => 0,
         'Getopt::Long'    => 0,
-        'LWP::UserAgent'  => 0,
         'Pod::Usage'      => 0,
-        "Pod::Usage"      => 0,
         "POSIX"           => 0,
+
+        # non-core modules
+        'LWP::UserAgent'  => 0,
         "Text::Template"  => 0,
         "Mojo::UserAgent" => 0,
-
+        },
+    TEST_REQUIRES => {
         # solely for the test-suite.
         'Test::More'   => 0,
         'Test::Pod'    => 0,
         'Test::Strict' => 0,
         'Test::NoTabs' => 0,
-
+        'Test::Script' => 0,
+        'Test::File::Contents' => 0,
+        'Capture::Tiny' => 0,
                  },
     ABSTRACT => 'The Slaughter System Administration Utility.',
     AUTHOR   => 'Steve Kemp <steve@steve.org.uk>',

--- a/bin/slaughter
+++ b/bin/slaughter
@@ -11,10 +11,7 @@ slaughter - Perl Automation Tool
   General Options:
 
    --delay         Delay for up to N seconds prior to launching.   Useful if you have a lot of clients.
-   --dump          Dump details of the local environment, and immediately exit.
    --mail          Email the output of any LogMessages to the given address.
-   --no-delete     Don't delete the compiled perl post-execution.
-   --no-execute    Don't actually execute the downloaded policy.
    --role          Specify a role for this host, useful for policy writers.
    --transports    Dump the names of all available transports.
    --include       Include the specified file in our wrapper content.
@@ -26,6 +23,19 @@ slaughter - Perl Automation Tool
    --username       The username for the policy-fetch, if appropriate (http-only).
    --password       The password for the policy-fetch, if appropriate (http-only).
    --transport-args Any arguments to pass to the transport (used for rsync/hg/git/svn).
+
+  Developing and debugging policies. Note that none of these settings should be
+        used on the target hosts.
+
+   --dump          Dump details of the local environment, and immediately exit.
+   --no-delete     Don't delete the compiled perl post-execution.
+   --no-execute    Don't actually execute the downloaded policy.
+   --skip-cfgfile  Don't read the config file.
+   --allow-nonroot Allow non-root users (also sets --no-execute).
+   --outfile       Write the generated script to this file (also sets --no-delete).
+   --lockfile      Specify the lockfile to use (useful with --allow-nonroot).
+   --fqdn          Spoof the fqdn.
+   --hostname      Spoof the hostname.
 
   Help Options:
 
@@ -141,6 +151,24 @@ may be executed interactively to see what is going on.
 You may also invoke slaughter with the C<--dump> flag which will cause
 it to display the environmental details it has discovered, and which will
 be compiled into the policy prior to execution.
+
+The C<--allow-nonroot> flag permits unprivileged users to run
+C<slaughter> and generate the update script. It doesn't allow them to run the
+generated script. This flag also sets the C<--no-execute> flag.
+
+You can use C<--role>, C<--hostname> and C<--fqdn> options to spoof particular
+environments and check the generated update script before deploying.
+
+You can set C<--outfile> to capture the generated script, instead of sending it
+to a randomly named tmpfile. This will also set the C<--no-delete> flag for you.
+
+For example:
+
+    slaughter --verbose --skip-cfgfile --allow-nonroot --lockfile=/tmp/slaug.lck \
+        --transport=local --prefix=/path/to/my/slaughter-policies \
+        --role=mailserver --hostname=smtp --fqdn=smtp.example.com \
+        --outfile=GENERATED.pl
+
 
 =cut
 
@@ -377,6 +405,8 @@ sub defaultOptions
                  transportargs => '',
                  nodelete      => 0,
                  noexecute     => 0,
+                 allownonroot => 0,
+                 skipcfgfile  => 0,
                  delay         => -1,
                );
 
@@ -548,6 +578,8 @@ sub parseConfigurationFile
 {
     my $config = undef;
 
+    return if $CONFIG{ 'skipcfgfile' };
+
     #
     #  Try each of the configuration files in turn.
     #
@@ -653,10 +685,15 @@ sub parseCommandLine
             "delay=i",    \$CONFIG{ 'delay' },
             "lockfile=s", \$CONFIG{ 'lockfile' },
             "role=s",     \$CONFIG{ 'role' },
+            "fqdn=s",     \$CONFIG{ 'fqdn' },
+            "hostname=s", \$CONFIG{ 'hostname' },
+            "outfile=s",  \$CONFIG{ 'outfile' },
             "transports", \$CONFIG{ 'transports' },
             "no-delete",  \$CONFIG{ 'nodelete' },
             "no-execute", \$CONFIG{ 'noexecute' },
             "verbose",    \$CONFIG{ 'verbose' },
+            "skip-cfgfile",  \$CONFIG{ 'skipcfgfile' },
+            "allow-nonroot", \$CONFIG{ 'allownonroot' },
         ) )
     {
         exit 1;
@@ -665,6 +702,21 @@ sub parseCommandLine
     pod2usage(1) if $SHOW_HELP;
     pod2usage( -verbose => 2 ) if $SHOW_MANUAL;
 
+    #
+    #  Don't bother trying to execute the generated script if we're allowing non-root
+    #
+    if ( $CONFIG{ 'allownonroot' } )
+    {
+        $CONFIG{ 'noexecute' } ||= 1;
+    }
+
+    #
+    # Don't delete the output file if it was specified on the command line
+    #
+    if ( $CONFIG{ 'outfile' } )
+    {
+        $CONFIG{ 'nodelete' } ||= 1;
+    }
 
     #
     #  Showing the version number only?
@@ -792,7 +844,7 @@ configuration file settings, and the local user.
 
 sub testEnvironment
 {
-    if ( $UID != 0 )
+    if ( $UID != 0 and ! $CONFIG{ 'allownonroot' })
     {
         print <<EOF;
 You must launch this command as root.
@@ -976,7 +1028,10 @@ sub loadPolicy
         # Skip blank lines
         next if ( length($line) < 1 );
 
-        if ( $line =~ /^([ \t]*)FetchPolicy(.*);*/ )
+        # Strip comments on end of line
+        $line =~ s/#.*$//;
+
+        if ( $line =~ /^([ \t]*)FetchPolicy(.*);\s*/ )
         {
             $::CONFIG{ 'verbose' } && print "Policy inclusion: $line\n";
 
@@ -1014,15 +1069,15 @@ sub loadPolicy
                                       file   => $include );
             if ($txt)
             {
-                $line = "# Policy inclusion - $include\n";
-                $line .= $txt;
+                $line = "{\n" . "# Policy inclusion - $include\n";
+                $line .= $txt . "}\n";
             }
             else
             {
                 $line = "# Policy inclusion failed - $include\n";
             }
         }
-        if ( $line =~ /^([ \t]*)FetchModule(.*);*/ )
+        if ( $line =~ /^([ \t]*)FetchModule(.*);\s*/ )
         {
             $::CONFIG{ 'verbose' } && print "Module inclusion: $line\n";
 
@@ -1040,8 +1095,8 @@ sub loadPolicy
                                       file   => $include );
             if ($tmp)
             {
-                $modules .= "\n# Module inclusion - $include\n";
-                $modules .= $tmp;
+                $modules .= "\n{\n" . "\n# Module inclusion - $include\n";
+                $modules .= $tmp . "}\n";
                 $line = "";
             }
             else
@@ -1083,6 +1138,7 @@ sub writeoutPolicy
     # it to something restrictive.
     #
     my ( undef, $name ) = File::Temp::tempfile();
+    $name = $CONFIG{ 'outfile' } if $CONFIG{ 'outfile' };
     if ( $^O ne "MSWin32" )
     {
         chmod( 0700, $name );

--- a/bin/slaughter
+++ b/bin/slaughter
@@ -637,6 +637,9 @@ sub parseConfigurationFile
             $val =~ s/^\s+//;
             $val =~ s/\s+$//;
 
+            # strip dashes in variable name
+            $key =~ s/-//g;
+
             # Store value.
             $CONFIG{ $key } = $val;
         }

--- a/bin/slaughter
+++ b/bin/slaughter
@@ -541,7 +541,10 @@ sub loadInfo
     eval("use $module");
     ## use critic
 
-    if ( !$@ )
+    if ($@) {
+        warn "Error loading info module $module: $@";
+    }
+    else
     {
 
         #
@@ -1073,7 +1076,10 @@ sub loadPolicy
             if ($txt)
             {
                 $line = "{\n" . "# Policy inclusion - $include\n";
-                $line .= $txt . "}\n";
+                $line .= "print '>>>>> Running policy: ---------------------- $include\n';\n" if $::CONFIG{verbose};
+                $line .= $txt;
+                $line .= "print '<<<<< Completed policy: -------------------- $include\n';\n" if $::CONFIG{verbose};
+                $line .= "}\n";
             }
             else
             {

--- a/lib/Slaughter/API/generic.pm
+++ b/lib/Slaughter/API/generic.pm
@@ -297,16 +297,20 @@ sub CommentLinesMatching
                 }
                 close($handle);
 
+                $::verbose && print "Commented $found lines matching $pattern in $file\n";
+
                 return $found;
             }
         }
         else
         {
+            $::verbose && print "No lines matching $pattern found in $file\n";
             return 0;
         }
     }
     else
     {
+        $::verbose && print "Couldn't open $file to check for $pattern\n";
         return -1;
     }
 }

--- a/t/example1/modules/Bar.pm
+++ b/t/example1/modules/Bar.pm
@@ -1,0 +1,9 @@
+package Bar;
+use strict;
+use warnings;
+
+# This is the Bar module
+
+my $modulefoo;
+
+1;

--- a/t/example1/modules/Foo.pm
+++ b/t/example1/modules/Foo.pm
@@ -1,0 +1,9 @@
+package Foo;
+use strict;
+use warnings;
+
+# This is the Foo module.
+
+my $modulefoo;
+
+1;

--- a/t/example1/policies/bar.policy
+++ b/t/example1/policies/bar.policy
@@ -1,0 +1,6 @@
+
+# This is the bar policy
+
+my $foo;
+
+die "No global thing" unless length($global_thing);

--- a/t/example1/policies/default.policy
+++ b/t/example1/policies/default.policy
@@ -1,0 +1,8 @@
+
+my $global_thing = 'useful everywhere';
+
+FetchModule("Foo.pm");          # the foo module
+FetchModule("Bar.pm");
+
+FetchPolicy("foo.policy");      # the foo policy
+FetchPolicy("bar.policy");

--- a/t/example1/policies/foo.policy
+++ b/t/example1/policies/foo.policy
@@ -1,0 +1,6 @@
+
+# This is the foo policy
+
+my $foo;
+
+die "No global thing" unless length($global_thing);

--- a/t/test-bin-slaughter.t
+++ b/t/test-bin-slaughter.t
@@ -1,0 +1,56 @@
+#!/usr/bin/perl -w -I../lib -I./lib/
+#
+
+use strict;
+use Test::More tests => 15;
+use Test::Script;
+use Test::File::Contents;
+
+use Cwd;
+use Capture::Tiny qw(capture);
+
+my $cwd = getcwd;
+
+my $prefix = "--prefix=$cwd/t/example1";
+my @args = qw(--verbose --skip-cfgfile --allow-nonroot
+                --lockfile=/tmp/slaug.lck --transport=local
+                --role=some_role --hostname=foohost --fqdn=barhost.baz.bam
+                --outfile=GENERATED.pl);
+
+push @args, $prefix;
+
+diag "Running slaughter with args: " . join(' ', @args);
+
+script_compiles('bin/slaughter', 'bin/slaughter compiles OK');
+
+my $stdout;
+script_runs(['bin/slaughter', @args], {stdout => \$stdout}, 'bin/slaughter runs OK');
+
+like($stdout, qr/Policy written to: GENERATED.pl\n/, 'Found expected output file name');
+
+file_contents_unlike 'GENERATED.pl',  qr/Policy inclusion failed/,  'All policy files included OK';
+file_contents_unlike 'GENERATED.pl',  qr/Module inclusion failed/,  'All module files included OK';
+
+file_contents_like 'GENERATED.pl',  qr/our \$hostname = 'foohost';/,      'hostname spoofed OK';
+file_contents_like 'GENERATED.pl',  qr/hostname => 'foohost',/,           'hostname spoofed OK';
+file_contents_like 'GENERATED.pl',  qr/our \$fqdn = 'barhost.baz.bam';/,  'fqdn spoofed OK';
+file_contents_like 'GENERATED.pl',  qr/fqdn => 'barhost.baz.bam',/,       'fqdn spoofed OK';
+file_contents_like 'GENERATED.pl',  qr/our \$role = 'some_role';/,        'role spoofed OK';
+file_contents_like 'GENERATED.pl',  qr/role => 'some_role',/,             'role spoofed OK';
+file_contents_like 'GENERATED.pl',  qr/our \$noexecute = '1';/,           'noexecute set OK';
+file_contents_like 'GENERATED.pl',  qr/noexecute => '1',/,                'noexecute set OK';
+
+script_compiles('GENERATED.pl', 'generated script compiles OK');
+
+# Check that re-declaring 'my' variables in multiple policy files does not raise warnings
+my ($stdout2, $stderr, @result) = capture {
+  system( 'perl', qw(-c GENERATED.pl) );
+};
+
+chomp($stderr);
+is($stderr, "GENERATED.pl syntax OK", 'generated script compiles with no warnings');
+diag "Compilation generated warning: $stderr" if $stderr ne 'GENERATED.pl syntax OK';
+
+
+
+unlink('GENERATED.pl');


### PR DESCRIPTION
Hi Steve, 

I found it non-intuitive when defining lexicals within individual policy files that it's necessary to not re-use variable names from other policy files because they all end up in the same scope in the generated file. So this PR simply wraps each policy file (and module file) in braces. Except for the default.policy file. So you can still define variables in default.policy and they will be 'globally' available in the other files. 

Also I added a bunch of options that I found useful for debugging policies locally, as a non-privileged user. 

And you can now say
FetchModule("MyMod.pm");  # fetch something useful
FetchPolicy("some.policy");  # fetch some policy
and the comments don't break the primitives. 

Thanks for a great tool!